### PR TITLE
Reduce repetition of branch and mode arguments.

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -285,6 +285,8 @@ def add_builder(slave_name, branch, port, platform="", full=False,
 
     build = make_build_desc(branch, port, platform, full)
 
+    # make_nmake_factory is excluded because it doesn't have a
+    # mode parameter (it always builds in full mode).
     if full and factory != make_nmake_factory:
         kwargs.update({"mode": "full"})
 

--- a/master.cfg
+++ b/master.cfg
@@ -280,6 +280,48 @@ def make_build_desc(branch, port, platform="", full=False):
     return {"name": n, "builddir": d}
 
 
+def add_builder(slave_name, branch, port, platform="", full=False,
+    factory=None, **kwargs):
+
+    build = make_build_desc(branch, port, platform, full)
+
+    if full and factory != make_nmake_factory:
+        kwargs.update({"mode": "full"})
+
+    build.update({"slavename": slave_name})
+    build.update({"factory": factory(branch, **kwargs)})
+
+    c["builders"].append(build)
+
+# Convenience function for add_builder to add an unstable master build.
+def add_master_builder(slave_name, port, platform="", full=False,
+    factory=None, **kwargs):
+
+    add_builder(
+        slave_name,
+        "master",
+        port,
+        platform,
+        full,
+        factory,
+        **kwargs
+    )
+
+# Convenience function for add_builder to add a stable branch build.
+def add_branch_builder(slave_name, port, platform="", full=False,
+    factory=None, **kwargs):
+
+    add_builder(
+        slave_name,
+        "WX_3_0_BRANCH",
+        port,
+        platform,
+        full,
+        factory,
+        **kwargs
+    )
+
+
 # Map platforms to the slaves using them.
 slave_for = {
         "Linux-i686":    "brandt32",
@@ -297,22 +339,23 @@ for br in ["master", "WX_3_0_BRANCH"]:
         else:
             raise "Unknown branch " + br
 
-        build = make_build_desc(br, "wxGTK-STL", pl)
-        build.update({
-                "slavename": slave_for[pl],
-                "factory": make_unix_factory(
-                    branch=br,
-                    config_args=["--enable-stl", disable_compat_arg]
-                ),
-            })
-        c["builders"].append(build)
+        add_builder(
+            slave_name=slave_for[pl],
+            branch=br,
+            port="wxGTK-STL",
+            platform=pl,
+            factory=make_unix_factory,
+            config_args=["--enable-stl", disable_compat_arg]
+        )
 
-        build = make_build_desc(br, "wxGTK", pl, full=True)
-        build.update({
-                "slavename": slave_for[pl],
-                "factory": make_unix_factory(br, mode="full"),
-            })
-        c["builders"].append(build)
+        add_builder(
+            slave_name=slave_for[pl],
+            branch=br,
+            port="wxGTK",
+            platform=pl,
+            full=True,
+            factory=make_unix_factory,
+        )
 
 # Set up OS X builds: things are more complicated here as they don't use the
 # same options with master and 3.0.
@@ -330,77 +373,64 @@ osx_args_min_10_9 = ["--with-macosx-version-min=10.9",
                      "--with-cppunit-prefix=/Developer/libc++variants/cppunit",
                     ]
 
-build = make_build_desc("master", "wxOSX-Cocoa")
-build.update({
-        "slavename": "csleobuild",
-        "factory": make_osx_factory(
-            config_args=osx_args_min_10_9 + osx_args_64_only,
-        ),
-    })
-c["builders"].append(build)
+add_master_builder(
+    slave_name="csleobuild",
+    port="wxOSX-Cocoa",
+    factory=make_osx_factory,
+    config_args=osx_args_min_10_9 + osx_args_64_only
+)
 
-build = make_build_desc("master", "wxOSX-Cocoa-10.7", full=True)
-build.update({
-        "slavename": "csleobuild",
-        "factory": make_osx_factory(
-            config_args=osx_args_min_10_7,
-            mode="full"
-        ),
-    })
-c["builders"].append(build)
+add_master_builder(
+    slave_name="csleobuild",
+    port="wxOSX-Cocoa-10.7",
+    full=True,
+    factory=make_osx_factory,
+    config_args=osx_args_min_10_7
+)
 
-build = make_build_desc("master", "wxiOS", full=True)
-build.update({
-        "slavename": "csleobuild",
-        "factory": make_ios_factory(mode="full"),
-    })
-c["builders"].append(build)
+add_master_builder(
+    slave_name="csleobuild",
+    port="wxiOS",
+    full=True,
+    factory=make_ios_factory
+)
 
-build = make_build_desc("WX_3_0_BRANCH", "wxOSX-Cocoa-10.5")
-build.update({
-        "slavename": "csleobuild",
-        "factory": make_osx_factory(
-            branch="WX_3_0_BRANCH",
-            config_args=osx_args_min_10_5,
-        ),
-    })
-c["builders"].append(build)
+add_branch_builder(
+    slave_name="csleobuild",
+    port="wxOSX-Cocoa-10.5",
+    factory=make_osx_factory,
+    config_args=osx_args_min_10_5
+)
 
-build = make_build_desc("WX_3_0_BRANCH", "wxOSX-Cocoa-10.5", full=True)
-build.update({
-        "slavename": "csleobuild",
-        "factory": make_osx_factory(
-            branch="WX_3_0_BRANCH",
-            config_args=osx_args_min_10_5,
-            mode="full"
-        ),
-    })
-c["builders"].append(build)
+add_branch_builder(
+    slave_name="csleobuild",
+    port="wxOSX-Cocoa-10.5",
+    full=True,
+    factory=make_osx_factory,
+    config_args=osx_args_min_10_5
+)
 
-build = make_build_desc("WX_3_0_BRANCH", "wxOSX-Carbon")
-build.update({
-        "slavename": "csleobuild",
-        "factory": make_osx_factory(
-            branch="WX_3_0_BRANCH",
-            config_args=["--with-osx_carbon"] + osx_args_min_10_5,
-        ),
-    })
-c["builders"].append(build)
+add_branch_builder(
+    slave_name="csleobuild",
+    port="wxOSX-Carbon",
+    factory=make_osx_factory,
+    config_args=["--with-osx_carbon"] + osx_args_min_10_5
+)
 
 # Set up MSW builds.
-build = make_build_desc("master", "wxMSW-VC8", full=True)
-build.update({
-        "slavename": "disc-xp",
-        "factory": make_nmake_factory(),
-    })
-c["builders"].append(build)
+add_master_builder(
+    slave_name="disc-xp",
+    port="wxMSW-VC8",
+    full=True,
+    factory=make_nmake_factory
+)
 
-build = make_build_desc("WX_3_0_BRANCH", "wxMSW-VC8", full=True)
-build.update({
-        "slavename": "disc-xp",
-        "factory": make_nmake_factory(branch="WX_3_0_BRANCH"),
-    })
-c["builders"].append(build)
+add_branch_builder(
+    slave_name="disc-xp",
+    port="wxMSW-VC8",
+    full=True,
+    factory=make_nmake_factory
+)
 
 ####### SCHEDULERS
 


### PR DESCRIPTION
Branch and mode arguments are being used while creating the build
description and repeated again when creating a factory. Instead use a
single function add_builder that refers to each argument only once to
reduce redundancy and make the build creation process less error-prone.
